### PR TITLE
lpf-664: override decoder bean as not required for tests

### DIFF
--- a/src/test/java/uk/gov/laa/pfla/configuration/TestConfig.java
+++ b/src/test/java/uk/gov/laa/pfla/configuration/TestConfig.java
@@ -9,6 +9,10 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.laa.gpfd.graph.GraphClient;
 import uk.gov.laa.gpfd.graph.StubbedGraphClient;
@@ -138,6 +142,15 @@ public class TestConfig {
             public Workbook getExcelWorkbook() {
                 return getExcelWorkbook(scenarioContext);
             }
+        };
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        return token -> {
+                // Simply parse the JWT without verification
+                return Jwt.withTokenValue(token)
+                        .build();
         };
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -24,10 +24,10 @@ spring:
       active-directory:
         enabled: true
         profile:
-          tenant-id: ${AZURE_TENANT_ID}
+          tenant-id: TestTenantId
         credential:
-          client-id: ${AZURE_CLIENT_ID}
-          client-secret: ${AZURE_CLIENT_SECRET}
+          client-id: TestClientId
+          client-secret: TestClientSecret
         redirect-uri-template: ${gpfd.redirect-uri-template}
         authorization-clients:
           graph:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,6 +11,7 @@ gpfd:
       username: sa
       password:
       driver-class-name: org.h2.Driver
+  jwks-uri: https://sts.windows.net/${spring.cloud.azure.active-directory.profile.tenant-id}/
 
 spring:
   main:
@@ -22,6 +23,12 @@ spring:
     azure:
       active-directory:
         enabled: true
+        profile:
+          tenant-id: ${AZURE_TENANT_ID}
+        credential:
+          client-id: ${AZURE_CLIENT_ID}
+          client-secret: ${AZURE_CLIENT_SECRET}
+        redirect-uri-template: ${gpfd.redirect-uri-template}
         authorization-clients:
           graph:
             scopes:


### PR DESCRIPTION
Remove dependency on real tenantid for testing
app requires values in client-id, tenant-id and client-secret, but these are unused so mock values is sufficient