### PR TITLE
[LPF-785]: Create Pod Configuration for gpfd-at-tests

### DIFF
--- a/deployment/pod.yaml
+++ b/deployment/pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: 'gpfd-at-tests'
+spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: gpfd-tests
+      image: ${TEST_IMAGE}
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ "ALL" ]

--- a/deployment/pod.yaml
+++ b/deployment/pod.yaml
@@ -16,5 +16,6 @@ spec:
       imagePullPolicy: IfNotPresent
       securityContext:
         allowPrivilegeEscalation: false
+        runAsNonRoot: true
         capabilities:
           drop: [ "ALL" ]


### PR DESCRIPTION
This PR implements the Pod configuration, ensuring compliance with Kubernetes security best practices. The gpfd-at-tests Pod will now run with restricted privileges and hardened settings.