### PR TITLE
LPF-914 - use deploy key instead of PAT

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -25,8 +25,7 @@
     <servers>
         <server>
             <id>github</id>
-            <username>${USERNAME}</username>
-            <password>${PASSWORD}</password>
+            <privateKey>${env.HOME}/.ssh/github_key</privateKey>
         </server>
     </servers>
 </settings>

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,18 @@ jobs:
           distribution: 'corretto'
           java-version: '17'
 
+      - name: Checkout openapi spec
+        uses: actions/checkout@v4
+        with:
+          repository: ministryofjustice/payforlegalaid-openapi
+          path: openapi
+          ssh-key: ${{ secrets.DEPLOY_KEY_OPENAPI }}
+
+      - name: Build openapi spec dependency
+        run: |
+          cd openapi
+          mvn -B clean install
+
       - name: Checkout source code repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,10 +6,6 @@ on:
   repository_dispatch:
     types: [ trigger-tests ]
 
-env:
-  USERNAME: ${{ secrets.OPENAPI_PACKAGE_USER }}
-  PASSWORD: ${{ secrets.OPENAPI_PACKAGE_PASSWORD }}
-
 jobs:
   run_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have replaced the use of Personal Access Tokens on our main repository. This change is to echo that change along to the acceptance tests, resolving an issue where they did not build.