### PR TITLE
Chore - bump openapi version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <cucumber.version>7.34.3</cucumber.version>
         <pay-for-legal-aid.version>0.0.1-SNAPSHOT</pay-for-legal-aid.version>
         <spring-cloud-azure-dependencies.version>7.0.0</spring-cloud-azure-dependencies.version>
-        <payforlegalaid-openapi.version>0.0.31</payforlegalaid-openapi.version>
+        <payforlegalaid-openapi.version>0.0.32</payforlegalaid-openapi.version>
         <playwright.version>1.58.0</playwright.version>
         <axe.version>4.11.1</axe.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>


### PR DESCRIPTION
Bumping openapi version to 0.0.32 for acceptance tests to pass for [LPF-716](https://dsdmoj.atlassian.net/browse/LPF-716)

[LPF-716]: https://dsdmoj.atlassian.net/browse/LPF-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ